### PR TITLE
Fix Ruby 3 quirks and allow to pass a list of arguments

### DIFF
--- a/lib/def_initialize.rb
+++ b/lib/def_initialize.rb
@@ -6,8 +6,10 @@ module DefInitialize
   require 'def_initialize/accessors_builder'
 
   class Mixin < Module
-    def initialize(args_str, readers: :private, writers: nil)
+    def initialize(*args, readers: :private, writers: nil)
       accessors_options = { readers_access_level: readers, writers_access_level: writers }
+
+      args_str = args.join(', ')
 
       # Create empty method just to inspect its parameters.
       module_eval <<-CODE, __FILE__, __LINE__ + 1
@@ -30,14 +32,14 @@ module DefInitialize
           #{rows.join("\n")}
         end
 
-        #{AccessorsBuilder.build(accessors, accessors_options)}
+        #{AccessorsBuilder.build(accessors, **accessors_options)}
       CODE
     end
   end
 
   class << self
-    def with(args_str, **opts)
-      Mixin.new(args_str, **opts)
+    def with(*args, **opts)
+      Mixin.new(*args, **opts)
     end
   end
 end

--- a/spec/def_initialize/accessors_builder_spec.rb
+++ b/spec/def_initialize/accessors_builder_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe DefInitialize::AccessorsBuilder do
-  subject { described_class.build(accessors, options) }
+  subject { described_class.build(accessors, **options) }
 
   let(:accessors) { [':x', ':y', ':z'] }
 

--- a/spec/def_initialize_spec.rb
+++ b/spec/def_initialize_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe DefInitialize do
     opts = options
 
     Class.new do
-      include DefInitialize.with(str, opts)
+      include DefInitialize.with(str, **opts)
     end
   end
 
@@ -82,7 +82,7 @@ RSpec.describe DefInitialize do
       Class.new do
         include DefInitialize.with("name, uuid = SecureRandom.uuid, age:, position: 'manager'")
 
-        def initialize(*args)
+        def initialize(name, **)
           super
 
           @age = 50


### PR DESCRIPTION
Something like this must be allowed for simple cases:

```ruby
def_initialize(:foo, :bar, :baz)
```
